### PR TITLE
update xbrlus url from http to https

### DIFF
--- a/R/xbrlus.R
+++ b/R/xbrlus.R
@@ -4,7 +4,7 @@
 #'
 #' All APIs (except for the CIKLookup) require use of a valid XBRL US API
 #' key. You can get the key and read the terms of usage at
-#' \url{http://xbrl.us/use/howto/data-analysis-toolkit/}.
+#' \url{https://xbrl.us/use/howto/data-analysis-toolkit/}.
 #'
 #' \pkg{xbrlus} functions will read the API key from environment variable
 #' \code{XBRLUS_API_KEY}.

--- a/R/xbrlus.R
+++ b/R/xbrlus.R
@@ -25,7 +25,7 @@
 #' @aliases xbrlus
 NULL
 
-xbrlus_url <- "http://csuite.xbrl.us/php/dispatch.php?"
+xbrlus_url <- "https://csuite.xbrl.us/php/dispatch.php?"
 
 
 


### PR DESCRIPTION
I received an email from the XBRL folks saying that they are shutting down the http connection tmrw. This just changes the `xbrlus_url` from http to https